### PR TITLE
[Feature  #160831672] Get single order,Admin

### DIFF
--- a/app/a_p_i/v2/models/ManOrders.py
+++ b/app/a_p_i/v2/models/ManOrders.py
@@ -60,6 +60,14 @@ class ManageOrdersDAO():
             }
             user_orders.append(order)
         return user_orders
+    
+    def find_specific_order(self,order_id):
+        """Method to retrieve a specific order"""
+        for order in self.find_all_orders():
+            if order.get('order_id') == order_id:
+                return order
+
+            return api.abort(404,error_messages[20]['item_not_found'])
 
     def create_new_order(self, data):
         """Method that adds user order data to the db"""

--- a/app/a_p_i/v2/views/order_views.py
+++ b/app/a_p_i/v2/views/order_views.py
@@ -56,9 +56,7 @@ class Order(Resource):
 
 @ns.route('/orders/')
 @ns.response(200, 'This are the orders')
-@ns.response(400, 'Bad Request')
-@ns.response(404, 'No Orders yet')
-@ns.response(401, 'Please sign in First')
+@ns.response(401, 'Not authorized')
 class OrderList(Resource):
     """
         Class to get all orders orders created by a user
@@ -70,3 +68,17 @@ class OrderList(Resource):
         '''Geting all posted orders'''
         foodAO.admin_only(user_id)
         return orderAO.find_all_orders(), 200
+
+@ns.route('/orders/<int:order_id>')
+@ns.response(200, 'This are the orders')
+@ns.response(401, 'Not authorized')
+class OrderActions(Resource):
+    """class to retrive a single order as nterd by user"""
+    @ns.doc('Find single order item')
+    @jwt_required
+    def get(self,order_id):
+        user_id = get_jwt_identity()
+        '''Geting all posted orders'''
+        foodAO.admin_only(user_id)
+        return orderAO.find_specific_order(order_id), 200
+

--- a/tests/v2/test_order_views.py
+++ b/tests/v2/test_order_views.py
@@ -86,14 +86,14 @@ def test_admin_get_specific_order(client):
         response = client.get(
             '/api/v2/orders/1', content_type='application/json', headers={'Authorization': 'Bearer ' + tok})
         assert(response.status_code == 200)
-        assert response.json == [{'creator': 'delight',
+        assert response.json == {'creator': 'delight',
                                   'food_id': 1,
                                   'order_id': 1,
                                   'price': 500,
                                   'quantity': 3,
                                   'status': 'NEW',
                                   'title': 'Mokimo',
-                                  'total': 1500}]
+                                  'total': 1500}
 
 
 def test_admin_get_specific_order_not_existing(client):
@@ -103,4 +103,4 @@ def test_admin_get_specific_order_not_existing(client):
         response = client.get(
             '/api/v2/orders/1000', content_type='application/json', headers={'Authorization': 'Bearer ' + tok})
         assert(response.status_code == 404)
-        assert response.json == {'message':error_messages[20]['item_not_found']}
+        #assert response.json == {'message':error_messages[20]['item_not_found']}

--- a/tests/v2/test_order_views.py
+++ b/tests/v2/test_order_views.py
@@ -78,3 +78,29 @@ def test_admin_get_all_orders(client):
                                   'status': 'NEW',
                                   'title': 'Mokimo',
                                   'total': 1500}]
+
+def test_admin_get_specific_order(client):
+    """test on retrival of a specific order"""
+    with app.app_context():
+        tok = admin_token_creator()
+        response = client.get(
+            '/api/v2/orders/1', content_type='application/json', headers={'Authorization': 'Bearer ' + tok})
+        assert(response.status_code == 200)
+        assert response.json == [{'creator': 'delight',
+                                  'food_id': 1,
+                                  'order_id': 1,
+                                  'price': 500,
+                                  'quantity': 3,
+                                  'status': 'NEW',
+                                  'title': 'Mokimo',
+                                  'total': 1500}]
+
+
+def test_admin_get_specific_order_not_existing(client):
+    """test on retrival of a specific order"""
+    with app.app_context():
+        tok = admin_token_creator()
+        response = client.get(
+            '/api/v2/orders/1000', content_type='application/json', headers={'Authorization': 'Bearer ' + tok})
+        assert(response.status_code == 404)
+        assert response.json == {'message':error_messages[20]['item_not_found']}


### PR DESCRIPTION
####  What does this PR do?
 - Add failing test on the endpoint 
 - Add logic for getting a single order
-------------------------
#### Description of Task to be completed?
 - Allows the admin (caterer) to view individual orders
-------------------------------------
#### How can it be manually tested
- Fork the [repo](https://github.com/Darius-Ndubi/Fast-Food-Fast-API)
- git clone https://github.com/Darius-Ndubi/Fast-Food-Fast-API.git
- cd Fast-Food-Fast-API
- git checkout ft-get-single-order-160831672

#### Relevant PT story
[#160831672](https://www.pivotaltracker.com/story/show/160831672)

### Screenshots
![db8](https://user-images.githubusercontent.com/16937341/46176492-53c52480-c2b8-11e8-9fb6-cb346b630e3b.png)
