### PR TITLE
Feature #161093581 Delete food item 

### DIFF
--- a/app/api/utility/messages.py
+++ b/app/api/utility/messages.py
@@ -60,5 +60,6 @@ success_messages = [
      " make modifications"},
     {'edit_success': 'Status update was successfull'},
     {'user_orders': "All users orders"},
-    {'user_order': 'Your orders'}
+    {'user_order': 'Your orders'},
+    {'Delete':"Deletion was successful"}
 ]

--- a/app/api/v2/models/food_model.py
+++ b/app/api/v2/models/food_model.py
@@ -151,3 +151,18 @@ class ManageFoodDAO():
         API.abort(500, error_messages[1]['validation_error'])
 
 
+    def delete_menu_item(self,food_id):
+        to_delete=self.check_food_existance_by_id(food_id)
+
+        if to_delete is None:
+            API.abort(404, error_messages[20]['item_not_found'])
+        connection = connectdb()
+        curs = connection.cursor()
+
+        curs.execute("DELETE FROM foods WHERE food_id=%(food_id)s",{
+            'food_id':food_id
+        })
+        curs.close()
+        connection.commit()
+        connection.close()
+        return {"Message":success_messages[7]['Delete']},200

--- a/app/api/v2/views/food_views.py
+++ b/app/api/v2/views/food_views.py
@@ -60,3 +60,11 @@ class FoodItem(Resource):
             API.abort(400, error_messages[25]['invalid_data'])
             
         return foodobject.edit_menu_item(food_id,edit_item)
+
+    @jwt_required
+    def delete(self,food_id):
+        """Method to delete food item from menu"""
+        user_id = get_jwt_identity()
+        foodobject.admin_only(user_id)
+
+        return foodobject.delete_menu_item(food_id)

--- a/tests/v2/test_food_views.py
+++ b/tests/v2/test_food_views.py
@@ -4,7 +4,7 @@ from flask import json
 # local imports
 from app import app
 from app.api.v2.db.conndb import connectdb
-from app.api.utility.messages import error_messages
+from app.api.utility.messages import error_messages,success_messages
 from tests.v1.test_yfood_views import mock_food,mock_up_food
 from tests.v2.test_auth_views import admin_token_creator
 
@@ -172,9 +172,24 @@ def test_on_retrieving_all_menu_items(client):
         '/api/v2/menu', content_type='application/json')
     assert response.status_code == 200
 
+def test_on_deleting_an_item_not_existing(client):
+    """Test on deleting a food item that doesnot exist"""
+    with app.app_context():
+        admin_token = admin_token_creator()
+        response = client.delete(
+            '/api/v2/menu/20000', content_type='application/json',
+            headers={'Authorization': 'Bearer ' + admin_token})
+        assert response.status_code == 404
 
 def test_on_deleting_an_item(client):
     """Test on deleting a food item"""
-    response = client.delete(
-        '/api/v2/menu/2', content_type='application/json')
-    assert response.status_code == 200
+    with app.app_context():
+        admin_token = admin_token_creator()
+        old_num_items = food_items()
+        response = client.delete(
+            '/api/v2/menu/2', content_type='application/json',
+            headers={'Authorization': 'Bearer ' + admin_token})
+        new_num_items = food_items()
+        assert new_num_items +1 == old_num_items
+        assert response.json == {'Message': success_messages[7]['Delete']}
+        assert response.status_code == 200

--- a/tests/v2/test_food_views.py
+++ b/tests/v2/test_food_views.py
@@ -171,3 +171,10 @@ def test_on_retrieving_all_menu_items(client):
     response = client.get(
         '/api/v2/menu', content_type='application/json')
     assert response.status_code == 200
+
+
+def test_on_deleting_an_item(client):
+    """Test on deleting a food item"""
+    response = client.delete(
+        '/api/v2/menu/2', content_type='application/json')
+    assert response.status_code == 200


### PR DESCRIPTION
####  What does this PR do?
 - Add test on deleting a food item
 - Add a feature to allow admin to delete food item
-------------------------
#### Description of Task to be completed?
 - Allow the admin to delete an existing food item
------------------------
#### How can it be manually tested
- Fork the [repo](https://github.com/Darius-Ndubi/Fast-Food-Fast-API)
- git clone https://github.com/Darius-Ndubi/Fast-Food-Fast-API.git
- cd Fast-Food-Fast-API
- git checkout ft-delete-food-item-161093581

## Relevant PT
[#161093581](https://www.pivotaltracker.com/story/show/161093581)

## Screenshot
![deletefood](https://user-images.githubusercontent.com/16937341/46689515-bb5c6780-cc08-11e8-9273-c729582d9017.png)
![deletefood1](https://user-images.githubusercontent.com/16937341/46689516-bbf4fe00-cc08-11e8-993a-3cea6a022808.png)

